### PR TITLE
Fix the following issues:

### DIFF
--- a/BackgroundAudio/BackgroundAudio-Prefix.pch
+++ b/BackgroundAudio/BackgroundAudio-Prefix.pch
@@ -11,4 +11,5 @@
 #ifdef __OBJC__
     #import <UIKit/UIKit.h>
     #import <Foundation/Foundation.h>
+    #import <MediaPlayer/MediaPlayer.h>
 #endif

--- a/BackgroundAudio/DetailViewController.m
+++ b/BackgroundAudio/DetailViewController.m
@@ -68,6 +68,13 @@
     [self.musicPlayer playSongWithId:self.songId];
     [[UIApplication sharedApplication] beginReceivingRemoteControlEvents];
     [self becomeFirstResponder];
+    
+    // add now-playing-info.  Without it, the lock screen playback controls will
+    // disappear once the user taps "pause".  Idealy, the song's artwork should
+    // be given, too.
+    [MPNowPlayingInfoCenter defaultCenter].nowPlayingInfo = [NSDictionary dictionaryWithObjectsAndKeys:self.songTitle, MPMediaItemPropertyTitle,
+                                     self.artistName, MPMediaItemPropertyArtist,
+                                     nil, nil ];
 }
 
 -(void) viewWillDisappear:(BOOL)animated

--- a/BackgroundAudio/MusicQuery.m
+++ b/BackgroundAudio/MusicQuery.m
@@ -60,7 +60,9 @@
                 NSString *songTitle =  [songMediumItem valueForProperty: MPMediaItemPropertyTitle];
                 NSNumber *persistentSongItemId = [songMediumItem valueForProperty:MPMediaItemPropertyPersistentID];
                 NSDictionary *artistAlbum = [songSortingArray objectForKey:albumName];
-                if (!artistAlbum) {
+                // sometimes the album name or artist name can be missing
+                // then we simply don't pick them to avoid a crash.
+                if (!artistAlbum && albumName && artistName) {
                     NSMutableArray *songs = [NSMutableArray array];
                     artistAlbum = [NSDictionary dictionaryWithObjects:[NSArray arrayWithObjects:artistName,albumName,songs,nil] 
                                                               forKeys:[NSArray arrayWithObjects:@"artist",@"album", @"songs",nil]];

--- a/BackgroundAudio/TestMusicPlayer.m
+++ b/BackgroundAudio/TestMusicPlayer.m
@@ -118,6 +118,14 @@
 
                 break;
             }
+            case UIEventSubtypeRemoteControlPlay: {
+                [[self avQueuePlayer] play];
+                break;
+            }
+            case UIEventSubtypeRemoteControlPause: {
+                [[self avQueuePlayer] pause];
+                break;
+            }
             default:
                 break;
         }


### PR DESCRIPTION
Some of my testing songs don't have complete info. For example, albumName is nil. It causes the app to crash when trying to assemble the dictionary for the song.

The background event handler considers only the RemoteControlTogglePlayPause event but on my phone (iPhone 4, iOS 7), tapping the pause button on the lock screen generates a RemoteControlPause event (similar issue with the play button).

After I fix issue 2, tapping the pause button does paused the music, but the playback lock screen (with playback controls) disappears, reverting back to the lock screen with wallpaper. This can be fixed by setting the nowPlayingInfo.
